### PR TITLE
Some changes of how aura router can make use of

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Remember how we created and called our controllers:
 
 ```php
 $controllerObject = new $controller();
-$controllerObject->$method();
+$controllerObject->$action();
 ```
 
 This is bad!
@@ -305,7 +305,7 @@ To make this possible, we need to call the action (`homepage()`) with the route 
 We can use `Container::call()` in PHP-DI to do this:
 
 ```php
-$container->call([$controller, $method], $parameters);
+$container->call([$controller, $action], $parameters);
 ```
 
 FYI the `$parameters` are obtained from the router when matching a route:


### PR DESCRIPTION
Hi @mnapoli ,

Some things I don't know are how the PHP-DI can make use of the `Aura\Router\Router` to be called instead of the `RouterFactory` .

Changed the array of controller and action to its own in the params. 

And for the dispatching we have been using Aura.Dispatcher which can recursively dispatch things.

Say you are returning a Response object which can print `Hello World` when invoked. In that case I am not sure whether the call works ? So the DI container seems doing dispatching also ?
